### PR TITLE
fix: Adding constructors and props to ViewContactEvent

### DIFF
--- a/lib/view_contact/bloc/view_contact_event.dart
+++ b/lib/view_contact/bloc/view_contact_event.dart
@@ -7,9 +7,19 @@ abstract class ViewContactEvent extends Equatable {
   List<Object> get props => [];
 }
 
-class DeleteContactEvent extends ViewContactEvent {}
+class DeleteContactEvent extends ViewContactEvent {
+  const DeleteContactEvent();
 
-class RefreshContactData extends ViewContactEvent {}
+  @override
+  List<Object> get props => [];
+}
+
+class RefreshContactData extends ViewContactEvent {
+  const RefreshContactData();
+
+  @override
+  List<Object> get props => [];
+}
 
 class GetContact extends ViewContactEvent {
   const GetContact({required this.contact});


### PR DESCRIPTION
As Bloc Tests showed, 
We should add constructors and props to ViewContactEvent